### PR TITLE
README.md: SerenityOS' => SerenityOS's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # LibJS Website
 
-Website for SerenityOS' JavaScript engine.
+Website for SerenityOS's JavaScript engine.


### PR DESCRIPTION
`'` is only used for plural nouns that end in `s`, all singluar nouns use `'s`. :^)